### PR TITLE
Read Chapters from ComicInfo.txt

### DIFF
--- a/comicon/inputs/cbz.py
+++ b/comicon/inputs/cbz.py
@@ -63,7 +63,7 @@ def create_cir(path: Path, dest: Path) -> Iterator[str | int]:
                                     chapters.append(Chapter(page.attrib["Bookmark"], slugify(page.attrib["Bookmark"], **SLUGIFY_ARGS)))
                                     chapter_index[page.attrib["Bookmark"]] = int(page.attrib["Image"])
                                 elif "Type" in page.attrib:
-                                    chapters.append(Chapter(page.attrib["Type"], slugidy(page.attrib["Type"], **SLUGIFY_ARGS)))
+                                    chapters.append(Chapter(page.attrib["Type"], slugify(page.attrib["Type"], **SLUGIFY_ARGS)))
                                     chapter_index[page.attrib["Type"]] = int(page.attrib["Image"])
             elif name.endswith(IR_DATA_FILE):
                 with z.open(name) as file:


### PR DESCRIPTION
Resolves #10 
This allows comicon to read chapters from .cbz files that are made available in the ComicInfo.xml file. The Bookmark is read, but also the Type (which is used for a fixed set of values like Table of Contents or Front Cover) because it seemed to me like a reasonable addition. If not its just 3 Lines to delete. 
This does **not** take care of writing this data **into** the ComicInfo.xml, but it will likely give a good baseline on how to achieve it. 